### PR TITLE
Fix boolean default types not decoding correctly

### DIFF
--- a/src/Builder/ClassProperty.php
+++ b/src/Builder/ClassProperty.php
@@ -60,6 +60,10 @@ class ClassProperty
             return '[]';
         }
 
+        if ($this->isBoolean() && is_bool($this->defaultValue)) {
+            return $this->defaultValue ? 'true' : 'false';
+        }
+
         if ($this->isString() && is_string($this->defaultValue)) {
             return sprintf("'%s'", $this->defaultValue);
         }
@@ -107,5 +111,10 @@ class ClassProperty
     public function isString(): bool
     {
         return $this->type === 'string';
+    }
+
+    public function isBoolean(): bool
+    {
+        return $this->type === 'bool';
     }
 }

--- a/src/Builder/DecoderTemplate.php
+++ b/src/Builder/DecoderTemplate.php
@@ -6,7 +6,7 @@ namespace Serializer\Builder;
 
 class DecoderTemplate implements FileTemplate
 {
-    private const TEMPLATE = <<<STIRNG
+    private const TEMPLATE = <<<STRING
 <?php /** @noinspection ALL */
 
 declare(strict_types=1);
@@ -41,7 +41,7 @@ class [cacheClassName] extends Decoder
         return [isCollection];
     }
 }
-STIRNG;
+STRING;
 
     private ClassDefinition $definition;
     private string $factoryName;

--- a/src/Builder/EncoderTemplate.php
+++ b/src/Builder/EncoderTemplate.php
@@ -6,7 +6,7 @@ namespace Serializer\Builder;
 
 class EncoderTemplate implements FileTemplate
 {
-    private const TEMPLATE = <<<STIRNG
+    private const TEMPLATE = <<<STRING
 <?php /** @noinspection ALL */
 
 declare(strict_types=1);
@@ -30,7 +30,7 @@ class [cacheClassName] extends Encoder
         return [isCollection];
     }
 }
-STIRNG;
+STRING;
 
     private ClassDefinition $definition;
     private string $factoryName;

--- a/tests/Fixture/Dto/DefaultValues.php
+++ b/tests/Fixture/Dto/DefaultValues.php
@@ -10,6 +10,7 @@ readonly class DefaultValues
      * @param int[] $array
      */
     public function __construct(
+        public bool $bool = true,
         public int $int = 15,
         public string $string = 'foo-bar',
         public float $float = 100.99,

--- a/tests/Unit/DefaultValuesTest.php
+++ b/tests/Unit/DefaultValuesTest.php
@@ -22,6 +22,7 @@ class DefaultValuesTest extends JsonSerializerTestCase
 
         $this->assertEquals(
             new DefaultValues(
+                bool: true,
                 int: 15,
                 string: 'foo-bar',
                 float: 100.99,
@@ -35,6 +36,7 @@ class DefaultValuesTest extends JsonSerializerTestCase
     #[Test] public function givenTheObjectThenParseIntoPayload(): void
     {
         $object = new DefaultValues(
+            bool: false,
             int: 20,
             string: 'something-else',
             float: 88.54,
@@ -48,6 +50,7 @@ class DefaultValuesTest extends JsonSerializerTestCase
             $json,
             <<<JSON
             {
+                "bool": false,
                 "int": 20,
                 "string": "something-else",
                 "float": 88.54,


### PR DESCRIPTION
Current usage results in no default value being provided and breaking the generated decoder:

<img width="551" height="48" alt="image" src="https://github.com/user-attachments/assets/0a46356b-41e2-4b98-96e0-de249e177dc7" />

This should help ensure that the default is correctly written as a truthy or falsy string:

<img width="756" height="167" alt="image" src="https://github.com/user-attachments/assets/b89194c0-d617-41cf-a09a-23690953ab10" />
